### PR TITLE
- Add Google Analytics code (which should also add Google Webmaster Tool...

### DIFF
--- a/src/templates/layout/base.html
+++ b/src/templates/layout/base.html
@@ -7,6 +7,14 @@
   <title>Pyramid: the start small, finish big, stay finished web framework</title>
   <link rel="stylesheet" href="{{['vendors', webpack.hash, 'css']|join('.')}}"/>
   <link rel="stylesheet" href="{{['app', webpack.hash, 'css']|join('.')}}"/>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-21146943-3', 'auto');
+    ga('send', 'pageview');
+  </script>
 </head>
 <body>
   <div id="pace-loader"></div>


### PR DESCRIPTION
...s when the GA code is deployed and the site is verified). It's supposed to be placed immediately before </head>. This will work, but there is probably a better method through webpack to include this as a separate .js file in the same location. I'll leave this optional step to @blaflamme. See #4.